### PR TITLE
KHI: fixes for production dataset

### DIFF
--- a/main/ModelHelpers/cINN/ks_producer_openPMD_streaming.py
+++ b/main/ModelHelpers/cINN/ks_producer_openPMD_streaming.py
@@ -183,6 +183,7 @@ class StreamLoader(Thread):
         """Function being executed when thread is started."""
         # Open openPMD particle and radiation series
         openpmd_stream_config = """
+            defer_iteration_parsing = true
             [adios2.engine.parameters]
             OpenTimeoutSecs = 300
         """


### PR DESCRIPTION
ADIOS2 aggregates data per node which makes it look like there were fewer GPUs involved than there actually were. This adds a little (somewhat dirty) workaround so the index calculations stay correct.

Also, add a parsing option to speed up startup. 