### PR TITLE
Use boxed particle and radiation data in ac_jr_fp_ks_openpmd-streaming-continual-learning.py

### DIFF
--- a/main/ModelHelpers/cINN/ac_jr_fp_ks_openpmd-streaming-continual-learning.py
+++ b/main/ModelHelpers/cINN/ac_jr_fp_ks_openpmd-streaming-continual-learning.py
@@ -49,12 +49,12 @@ streamLoader_config = dict(
     number_particles_per_gpu = 1000
 )
 
-#particleDataTransformationPolicy = BoxesAttributesParticles()
-particleDataTransformationPolicy = ParticlesAttributes() #returns particle data of shape (number_of_particles, ps_dims)
+particleDataTransformationPolicy = BoxesAttributesParticles() #returns particle data of shape (local ranks, number_of_particles, ps_dims)
+#particleDataTransformationPolicy = ParticlesAttributes() #returns particle data of shape (number_of_particles, ps_dims)
 
-# radiationDataTransformationPolicy = PerpendicularAbsoluteAndPhase()
-#radiationDataTransformationPolicy = AbsoluteSquare()
-radiationDataTransformationPolicy = AbsoluteSquareSumRanks() # returns radiation data of shape (frequencies)
+# radiationDataTransformationPolicy = PerpendicularAbsoluteAndPhase() #returns radiation data of shape (local ranks, frequencies)
+radiationDataTransformationPolicy = AbsoluteSquare() #returns radiation data of shape (local ranks, frequencies)
+#radiationDataTransformationPolicy = AbsoluteSquareSumRanks() # returns radiation data of shape (frequencies)
 
 timeBatchLoader = StreamLoader(openPMDBuffer, streamLoader_config, particleDataTransformationPolicy, radiationDataTransformationPolicy) ## Streaming ready
 


### PR DESCRIPTION
@Ankush7890 Now the `StreamLoader` provides boxed data, as previously.