### PR TITLE
Distributed, continual learning on Frontier

### DIFF
--- a/main/ModelHelpers/cINN/README.md
+++ b/main/ModelHelpers/cINN/README.md
@@ -1,12 +1,12 @@
 In order to train the model do:
 
 1. obtain a gpu (node)
-   both: `getDevice`
-   frontier: `NUM_GPUS=1; salloc --time=10:00 --nodes=1 --ntasks=$NUM_GPUS --gres=gpu:$NUM_GPUS --cpus-per-task=7 --ntasks-per-gpu=1 --gpu-bind=closest --mem-per-gpu=64000 -p batch -q debug -A csc380`
+   ATTENTION: Slurm option `--gpu-bind=closest` only works when requesting a full node`. When using less GPUs per node, dropping the option helps to avoid NCCL errors!
+   frontier: `export WORLD_SIZE=8; salloc --time=00:20:00 --nodes=1 --ntasks=$WORLD_SIZE --gres=gpu:$WORLD_SIZE --cpus-per-task=7 --ntasks-per-gpu=1 --mem-per-gpu=64000 -p batch -q debug -A csc380 -C nvme`
    hemera: `srun --time=10:00:00 --ntasks-per-node=1 --cpus-per-task=2 --gres=gpu:1 --mem=128G --partition=gpu --pty bash`
 
 2. load openPMD environment:
-   fontier: `CURRENT_DIR=$PWD; cd /lustre/orion/csc380/proj-shared/openpmd_environment; source env.sh; cd $CURRENT_DIR`
+   fontier: `source /lustre/orion/csc380/proj-shared/openpmd_environment/env.sh`
    hemera: `CURRENT_DIR=$PWD; cd /bigdata/hplsim/scratch/poesch58/InSituML_env; source env.sh; cd $CURRENT_DIR`
    * To create a new environment on hemera:
       ```bash
@@ -17,25 +17,30 @@ In order to train the model do:
 
 3. Change to directory `InSituML/main/ModelHelpers/cINN` and
    * adjust path to data in `io_config.py` (`pathpattern1` and `pathpattern2` (already there, but commented-out)) to
-	 frontier path to data: `/lustre/orion/csc380/world-shared/ksteinig/002_KHI_withRad_randomInit_data-subset`
+      - frontier path to data with 08GPUs: `/lustre/orion/csc380/world-shared/ksteinig/008_KHI_withRad_randomInit_8gpus/simOutput`
+      - frontier path to data with 16GPUs: `/lustre/orion/csc380/world-shared/ksteinig/016_KHI_withRad_randomInit_16gpus/simOutput`
+      - frontier path to data with 32GPUs: `/lustre/orion/csc380/world-shared/ksteinig/002_KHI_withRad_randomInit_data-subset`
    * `streamin_config` to `None` (to train from file),
-   * path to pre-trained model in `io_config.py` to should not need to be adjusted.
+   * path to pre-trained model in `io_config.py` should not need to be adjusted.
    * **There is also `io_config_frontier_offline.py`** which has these settings,
      see below.
 
-4. run training in an interactive job by continual learning with stream loader (on single gpu):
+4. run training in an interactive job by continual, distributed learning with stream loader.
+   Numer of GPUs for training depends on `NUM_GPUS` in step 1. above:
 
    frontier:
    ```bash
+   $ # export WORLD_SIZE=NUM_GPUS has been done when allocating resources
    $ cd /lustre/orion/csc380/proj-shared/ksteinig/2024-03_Training-from-Stream/job_temp
-   $ export MIOPEN_USER_DB_PATH="$(pwd)"; export MIOPEN_DISABLE_CACHE=1
-   $ srun python ~/src/InSituML/main/ModelHelpers/cINN/ac_jr_fp_ks_openpmd-streaming-continual-learning.py
+   $ export MIOPEN_USER_DB_PATH="/mnt/bb/$USER"; export MIOPEN_DISABLE_CACHE=1
+   $ export MASTER_PORT=12340; export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+   $ srun python ~/src/InSituML/main/ModelHelpers/cINN/ac_jr_fp_ks_openpmd-streaming-continual-learning.py --io_config ~/src/InSituML/main/ModelHelpers/cINN/io_config_frontier_offline.py 2>err.txt | tee out.txt
    ```
-   Add `--type_streamer offline` to work from file with any number of GPUs.
-   This will send a random permutations of all data to all ranks.  All data is
-   send to all ranks, i.e. the number of epochs/work increase with number GPUs.
-   Can be controlled with in `io_config.py` in `streamLoader_config` with the
-   `num_epochs` parameter, which may be fractional.
+   Add `--type_streamer 'streaming'` to work from file but using the `StreamingLoader` instead of `RandomLoader`.
+   This will aid testing the streaming, continual, distributed learning workflow without requiring a PIConGPU simulation producing the data at the same time.
+   `RandomLoader` will send a random permutations of all data to all ranks.
+   All data is send to all ranks, i.e. the number of epochs/work increase with number GPUs.
+   Can be controlled in `io_config.py` with the `num_epochs` parameter in `streamLoader_config`, which may be fractional.
 
    hemera:
    ```bash

--- a/main/ModelHelpers/cINN/io_config_frontier_offline.py
+++ b/main/ModelHelpers/cINN/io_config_frontier_offline.py
@@ -21,12 +21,16 @@ streamLoader_config = dict(
     t0 = 890,
     t1 = 898, # endpoint=false, t1 is not used in training
     streaming_config = None, # set to None when reading from file
-    pathpattern1 = "/lustre/orion/csc380/world-shared/ksteinig/002_KHI_withRad_randomInit_data-subset/openPMD/simData_%T.bp", # files on frontier
-    pathpattern2 = "/lustre/orion/csc380/world-shared/ksteinig/002_KHI_withRad_randomInit_data-subset/radiationOpenPMD/e_radAmplitudes%T.bp", # files on frontier
+#    pathpattern1 = "/lustre/orion/csc380/world-shared/ksteinig/008_KHI_withRad_randomInit_8gpus/simOutput/openPMD/simData_%T.bp5", # files for 8GPUs on frontier
+#    pathpattern2 = "/lustre/orion/csc380/world-shared/ksteinig/008_KHI_withRad_randomInit_8gpus/simOutput/radiationOpenPMD/e_radAmplitudes_%T.bp5", # files for 8GPUs on frontier
+    pathpattern1 = "/lustre/orion/csc380/world-shared/ksteinig/016_KHI_withRad_randomInit_16gpus/simOutput/openPMD/simData_%T.bp5", # files for 16GPUs on frontier
+    pathpattern2 = "/lustre/orion/csc380/world-shared/ksteinig/016_KHI_withRad_randomInit_16gpus/simOutput/radiationOpenPMD/e_radAmplitudes_%T.bp5", # files for 16GPUs on frontier
+#    pathpattern1 = "/lustre/orion/csc380/world-shared/ksteinig/002_KHI_withRad_randomInit_data-subset/openPMD/simData_%T.bp", # files for 32GPUs on frontier
+#    pathpattern2 = "/lustre/orion/csc380/world-shared/ksteinig/002_KHI_withRad_randomInit_data-subset/radiationOpenPMD/e_radAmplitudes%T.bp", # files for 32GPUs  on frontier
     amplitude_direction=0, # choose single direction along which the radiation signal is observed, max: N_observer-1, where N_observer is defined in PIConGPU's radiation plugin
     phase_space_variables = ["momentum", "force"], # allowed are "position", "momentum", and "force". If "force" is set, "momentum" needs to be set too.
     normalization = normalization_values,
-    number_particles_per_gpu = 1000,
+    number_particles_per_gpu = 4096,
     ## offline training params
     num_epochs = .25
 )
@@ -41,3 +45,4 @@ trainBatchBuffer_config = dict(
 
 runner="srun"
 type_streamer="offline"
+

--- a/main/ModelHelpers/cINN/io_config_frontier_streaming.py
+++ b/main/ModelHelpers/cINN/io_config_frontier_streaming.py
@@ -1,0 +1,37 @@
+
+import pathlib
+
+modelPathPattern = str(pathlib.Path(__file__).parent.resolve()) + '/trained_models/{}/best_model_'
+
+#######################################
+## openPMD data loader configuration ##
+#######################################
+ps_dims = 6 # Actually used in the model configuration by now
+            # ToDo: Use in StreamingLoader
+
+number_of_particles = 1000
+
+normalization_values = dict(
+    momentum_mean = 0.,
+    momentum_std = 1.,
+    force_mean = 0.,
+    force_std = 1.,
+)
+
+streamLoader_config = dict(
+    t0 = 890,
+    t1 = 900, # endpoint=false, t1 is not used in training
+    pathpattern1 = "openPMD/simData.sst", # streaming on frontier
+    pathpattern2 = "radiationOpenPMD/e_radAmplitudes.sst", # streaming on frontier
+    streaming_config = "@inconfig.json", #None, # set to None when reading from file
+    #pathpattern1 = "/lustre/orion/csc380/world-shared/ksteinig/002_KHI_withRad_randomInit_data-subset/openPMD/simData_%T.bp", # files on frontier
+    #pathpattern2 = "/lustre/orion/csc380/world-shared/ksteinig/002_KHI_withRad_randomInit_data-subset/radiationOpenPMD/e_radAmplitudes%T.bp", # files on frontier
+    amplitude_direction=0, # choose single direction along which the radiation signal is observed, max: N_observer-1, where N_observer is defined in PIConGPU's radiation plugin
+    phase_space_variables = ["momentum", "force"], # allowed are "position", "momentum", and "force". If "force" is set, "momentum" needs to be set too.
+    normalization = normalization_values,
+    number_particles_per_gpu = number_of_particles
+)
+
+runner = "srun"
+type_streamer = "streaming"
+

--- a/picongpu_setup_KHI/etc/picongpu/8_rad.cfg
+++ b/picongpu_setup_KHI/etc/picongpu/8_rad.cfg
@@ -30,14 +30,14 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="23:53:00"
+TBG_wallTime="00:20:00"
 
-TBG_devices_x=4
+TBG_devices_x=1
 TBG_devices_y=8
 TBG_devices_z=1
 
 TBG_gridSize="192 256 12"
-TBG_steps="2000"
+TBG_steps="900"
 
 TBG_periodic="--periodic 1 1 1"
 
@@ -46,27 +46,18 @@ TBG_periodic="--periodic 1 1 1"
 ## Section: Optional Variables ##
 #################################
 
-# file I/O
-# !!! this should be switched to streaming !!!
+# file output
 TBG_openPMD="--openPMD.period 890:2000:1   \
-             --openPMD.file forSteaming \
-              --openPMD.source e_all  \
-             --openPMD.ext bp"
-
-
-# this is the one output to disk requested by ML team 
-TBG_openPMD_toDisk="--openPMD.period 950:950:1   \
-                    --openPMD.file onDisk \
-                    --openPMD.source e_all  \
-                    --openPMD.ext bp"
-
-
-
+             --openPMD.file simData \
+             --openPMD.source 'e_all'  \
+             --openPMD.infix '_%T'    \
+             --openPMD.ext bp5    \
+             --openPMD.dataPreparationStrategy mappedMemory"
 
 TBG_radiation=" --e_radiation.period 1  --e_radiation.dump 1  \
-                --e_radiation.start 890 --e_radiation.end 2000
+                --e_radiation.start 890 --e_radiation.end 2000 \
                 --e_radiation.lastRadiation --e_radiation.totalRadiation  \
-                --e_radiation.openPMDSuffix %T.bp  --e_radiation.distributedAmplitude 1 "
+                --e_radiation.openPMDSuffix '_%T.bp5'  --e_radiation.distributedAmplitude 1"
 
 
 # not needed for Frontier runs, but nice to have in case we need to show simple physics 
@@ -77,7 +68,6 @@ TBG_iBin="--i_energyHistogram.period 100 --i_energyHistogram.filter all --i_ener
 TBG_plugins=" !TBG_eBin                     \
               !TBG_iBin                     \
               !TBG_openPMD                  \
-              !TBG_openPMD_toDisk           \
               !TBG_radiation                \
               --i_macroParticlesCount.period 100         \
               --e_macroParticlesCount.period 100         \

--- a/picongpu_setup_KHI/etc/picongpu/8_rad_streaming.cfg
+++ b/picongpu_setup_KHI/etc/picongpu/8_rad_streaming.cfg
@@ -30,13 +30,13 @@
 ## Section: Required Variables ##
 #################################
 
-TBG_wallTime="00:10:00"
+TBG_wallTime="00:20:00"
 
 TBG_devices_x=1
 TBG_devices_y=8
 TBG_devices_z=1
 
-TBG_gridSize="48 256 12"
+TBG_gridSize="192 256 12"
 TBG_steps="900" #"2000"
 
 TBG_periodic="--periodic 1 1 1"
@@ -81,11 +81,11 @@ TBG_PIC_config="\
 # Streaming output
 TBG_openPMD="--openPMD.period 890:900:1   \
   --openPMD.file simData \
-  --openPMD.source e_all \
-             --openPMD.infix NULL                           \
-             --openPMD.ext sst                              \
-             --openPMD.dataPreparationStrategy mappedMemory \
-             --openPMD.json '!TBG_PIC_config'"
+  --openPMD.source 'e_all' \
+  --openPMD.infix NULL                           \
+  --openPMD.ext sst                              \
+  --openPMD.dataPreparationStrategy mappedMemory \
+  --openPMD.json '!TBG_PIC_config'"
 
 TBG_streamdir="openPMD/simData.sst"
 TBG_dumpdir="openPMD/simData.bp"
@@ -93,17 +93,16 @@ TBG_dumpdir="openPMD/simData.bp"
 # File output
 # this is the one output to disk requested by ML team 
 TBG_openPMD_toDisk="--openPMD.period 950:950:1   \
-                    --openPMD.file simData \
-                    --openPMD.source e_all  \
-                    --openPMD.ext bp"
-
-
-
+  --openPMD.file simData \
+  --openPMD.source 'e_all'  \
+  --openPMD.infix '_%T'  \
+  --openPMD.ext bp5 \
+  --openPMD.dataPreparationStrategy mappedMemory"
 
 TBG_radiation=" --e_radiation.period 1  --e_radiation.dump 1  \
-                --e_radiation.start 890 --e_radiation.end 2000 \
-                --e_radiation.lastRadiation --e_radiation.totalRadiation  \
-                --e_radiation.openPMDSuffix sst --e_radiation.openPMDConfig '!TBG_PIC_config' \
+  --e_radiation.start 890 --e_radiation.end 2000 \
+  --e_radiation.lastRadiation --e_radiation.totalRadiation  \
+  --e_radiation.openPMDSuffix sst --e_radiation.openPMDConfig '!TBG_PIC_config' \
   --e_radiation.distributedAmplitude 1"
 
 # Configuration for the StreamingLoader, will be written to json file during execution of tbg

--- a/picongpu_setup_KHI/etc/picongpu/frontier-ornl/batch_pipe.tpl
+++ b/picongpu_setup_KHI/etc/picongpu/frontier-ornl/batch_pipe.tpl
@@ -312,15 +312,9 @@ chmod +x ./tmp.sh
 sbcast ./tmp.sh /mnt/bb/$USER/sync_bins/launch.sh
 rm ./tmp.sh
 
-TORCH_SCRATCH="/mnt/bb/$USER"
 
-mkdir -p $TORCH_SCRATCH
-
-## Say torch to write to scratch directory
-export MIOPEN_USER_DB_PATH="$TORCH_SCRATCH"
-export MIOPEN_DISABLE_CACHE=1
-
-insituml=/autofs/nccs-svm1_home1/fpoeschel/git-repos/InSituML
+#insituml=/autofs/nccs-svm1_home1/fpoeschel/git-repos/InSituML
+insituml=/autofs/nccs-svm1_home1/ksteinig/src/InSituML
 
 oldpwd="$(pwd)"
 pushd "${insituml%/*}"
@@ -333,6 +327,13 @@ if [ $node_check_err -eq 0 ] || [ $run_cuda_memtest -eq 0 ] ; then
     ##################
     ## Run InSituML ##
     ##################
+    ## Say torch to write to scratch directory
+    export MIOPEN_USER_DB_PATH="/mnt/bb/$USER"
+    export MIOPEN_DISABLE_CACHE=1
+    export MASTER_PORT=12340
+    export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+    export WORLD_SIZE=!TBG_tasks
+
     echo "Start InSituML"
     test $n_broken_nodes -ne 0 && exclude_nodes="-x./bad_nodes.txt"
 
@@ -359,6 +360,7 @@ if [ $node_check_err -eq 0 ] || [ $run_cuda_memtest -eq 0 ] ; then
       /mnt/bb/$USER/sync_bins/launch.sh           \
       /mnt/bb/$USER/sync_bins/python              \
         "/mnt/bb/$USER/InSituML/main/ModelHelpers/cINN/ac_jr_fp_ks_openpmd-streaming-continual-learning.py" \
+        --io_config /mnt/bb/$USER/InSituML/main/ModelHelpers/cINN/io_config_frontier_streaming.py --runner srun \
         > ../training.out 2> ../training.err              &
 
     sleep 1

--- a/picongpu_setup_KHI/include/picongpu/param/memory.param
+++ b/picongpu_setup_KHI/include/picongpu/param/memory.param
@@ -40,7 +40,7 @@ namespace picongpu
      *   - reduces
      *   - ...
      */
-    constexpr size_t reservedGpuMemorySize = 2ULL * 1024 * 1024 * 1024; // 2GiB
+    constexpr size_t reservedGpuMemorySize = 28ULL * 1024 * 1024 * 1024; // 28GiB
 
     /* short namespace*/
     namespace mCT = pmacc::math::CT;


### PR DESCRIPTION
Incorporating latest changes by @jkelling into streaming workflow and making it run with the DDP model.

@vgutta can follow the instructions in `README.md` in order to test distributed learning from files on 1, 2, and 4 nodes.