### PR TITLE
remove window function

### DIFF
--- a/picongpu_setup_KHI/include/picongpu/param/radiation.param
+++ b/picongpu_setup_KHI/include/picongpu/param/radiation.param
@@ -188,7 +188,7 @@ namespace picongpu
             {
             }
 
-            namespace radWindowFunction = radWindowFunctionTriplett;
+            namespace radWindowFunction = radWindowFunctionNone;
 
         } // namespace radiation
     } // namespace plugins


### PR DESCRIPTION
This removes the radiation window function, accidentally included in the KHI setup. 