### PR TITLE
Adds a restriction on the setting of consume size, sets larger number_particles_per_gpu

### DIFF
--- a/main/ModelHelpers/cINN/io_config.py
+++ b/main/ModelHelpers/cINN/io_config.py
@@ -20,7 +20,7 @@ streamLoader_config = dict(
     #pathpattern2 = "/lustre/orion/csc380/world-shared/ksteinig/002_KHI_withRad_randomInit_data-subset/radiationOpenPMD/e_radAmplitudes%T.bp", # files on frontier
     amplitude_direction=0, # choose single direction along which the radiation signal is observed, max: N_observer-1, where N_observer is defined in PIConGPU's radiation plugin
     phase_space_variables = ["momentum", "force"], # allowed are "position", "momentum", and "force". If "force" is set, "momentum" needs to be set too.
-    number_particles_per_gpu = 4000,
+    number_particles_per_gpu = 1000,
     ## offline training params
     num_epochs = 1
 )

--- a/main/ModelHelpers/cINN/ks_producer_openPMD.py
+++ b/main/ModelHelpers/cINN/ks_producer_openPMD.py
@@ -160,6 +160,7 @@ class RandomLoader(Thread):
                         loaded_particles[writing_index+i_c] = torch_stack([
                             torch_from_numpy(momentum[r]) for r in randomParticles
                         ])
+                        writing_index +=3
                         del momentum
                         
                     if "force" in self.reqPhaseSpaceVars:


### PR DESCRIPTION
- Larger consume size is required for not letting the train buffer hang for the first batch pass. 
- Smaller `number_particles_per_gpu` outputs the nan in the reader.