### PR TITLE
Add new KHI setup to dtensor

### DIFF
--- a/picongpu_setup_KHI/etc/picongpu/4_rad.cfg
+++ b/picongpu_setup_KHI/etc/picongpu/4_rad.cfg
@@ -1,0 +1,96 @@
+# Copyright 2013-2022 Axel Huebl, Rene Widera, Felix Schmitt
+#
+# This file is part of PIConGPU.
+#
+# PIConGPU is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PIConGPU is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PIConGPU.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+##
+## This configuration file is used by PIConGPU's TBG tool to create a
+## batch script for PIConGPU runs. For a detailed description of PIConGPU
+## configuration files including all available variables, see
+##
+##                      docs/TBG_macros.cfg
+##
+
+
+#################################
+## Section: Required Variables ##
+#################################
+
+TBG_wallTime="24:00:00"
+
+TBG_devices_x=1
+TBG_devices_y=4
+TBG_devices_z=1
+
+TBG_gridSize="192 256 12"
+TBG_steps="1000"
+
+TBG_periodic="--periodic 1 1 1"
+
+
+#################################
+## Section: Optional Variables ##
+#################################
+
+# file output
+TBG_outputStart="890"
+TBG_openPMD="--openPMD.period !TBG_outputStart:!TBG_steps:1   \
+             --openPMD.file simData \
+             --openPMD.source 'e_all'  \
+             --openPMD.infix '_%T'    \
+             --openPMD.ext bp5    \
+             --openPMD.dataPreparationStrategy mappedMemory"
+
+TBG_radiation=" --e_radiation.period 1  --e_radiation.dump 1  \
+                --e_radiation.start !TBG_outputStart --e_radiation.end !TBG_steps \
+                --e_radiation.lastRadiation --e_radiation.totalRadiation  \
+                --e_radiation.openPMDSuffix '_%T.bp5'  --e_radiation.distributedAmplitude 1"
+
+
+# not needed for Frontier runs, but nice to have in case we need to show simple physics 
+# [in keV]
+TBG_eBin="--e_energyHistogram.period 100 --e_energyHistogram.filter all --e_energyHistogram.binCount 1024 --e_energyHistogram.minEnergy 0 --e_energyHistogram.maxEnergy 5000"
+TBG_iBin="--i_energyHistogram.period 100 --i_energyHistogram.filter all --i_energyHistogram.binCount 1024 --i_energyHistogram.minEnergy 0 --i_energyHistogram.maxEnergy 2000000"
+
+TBG_plugins=" !TBG_eBin                     \
+              !TBG_iBin                     \
+              !TBG_openPMD                  \
+              !TBG_radiation                \
+              --i_macroParticlesCount.period 100         \
+              --e_macroParticlesCount.period 100         \
+              --fields_energy.period 10                  \
+              --e_energy.period 10 --e_energy.filter all \
+              --i_energy.period 10 --i_energy.filter all"
+
+
+#################################
+## Section: Program Parameters ##
+#################################
+
+TBG_deviceDist="!TBG_devices_x !TBG_devices_y !TBG_devices_z"
+
+TBG_programParams="-d !TBG_deviceDist \
+                   -g !TBG_gridSize   \
+                   -s !TBG_steps      \
+                   !TBG_periodic      \
+                   !TBG_plugins       \
+                   --versionOnce"
+
+# TOTAL number of devices
+TBG_tasks="$(( TBG_devices_x * TBG_devices_y * TBG_devices_z ))"
+
+"$TBG_cfgPath"/submitAction.sh

--- a/picongpu_setup_KHI/include/picongpu/param/density.param
+++ b/picongpu_setup_KHI/include/picongpu/param/density.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
+/* Copyright 2013-2024 Axel Huebl, Heiko Burau, Rene Widera, Felix Schmitt,
  *                     Richard Pausch
  *
  * This file is part of PIConGPU.
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -22,22 +22,8 @@
 
 #include "picongpu/particles/densityProfiles/profiles.def"
 
-
 namespace picongpu
 {
-    namespace SI
-    {
-        /** Base density in particles per m^3 in the density profiles.
-         *
-         * This is often taken as reference maximum density in normalized profiles.
-         * Individual particle species can define a `densityRatio` flag relative
-         * to this value.
-         *
-         * unit: ELEMENTS/m^3
-         */
-        constexpr float_64 BASE_DENSITY_SI = 1.e25;
-    } // namespace SI
-
     namespace densityProfiles
     {
         /* definition of homogenous profile */

--- a/picongpu_setup_KHI/include/picongpu/param/dimension.param
+++ b/picongpu_setup_KHI/include/picongpu/param/dimension.param
@@ -1,4 +1,4 @@
-/* Copyright 2014-2022 Axel Huebl, Rene Widera
+/* Copyright 2014-2024 Axel Huebl, Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License

--- a/picongpu_setup_KHI/include/picongpu/param/memory.param
+++ b/picongpu_setup_KHI/include/picongpu/param/memory.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz
+/* Copyright 2013-2024 Axel Huebl, Rene Widera, Benjamin Worpitz
  *
  * This file is part of PIConGPU.
  *
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -40,7 +40,7 @@ namespace picongpu
      *   - reduces
      *   - ...
      */
-    constexpr size_t reservedGpuMemorySize = 28ULL * 1024 * 1024 * 1024; // 28GiB
+    constexpr size_t reservedGpuMemorySize = 400 * 1024 * 1024;
 
     /* short namespace*/
     namespace mCT = pmacc::math::CT;
@@ -101,7 +101,7 @@ namespace picongpu
          * 1.0 means it scales linear with the ratio between the local domain size at runtime and the reference local
          * domain size.
          */
-        const std::array<float_X, 3> DIR_SCALING_FACTOR = {{1.0, 1.0, 1.0}};
+        std::array<float_X, 3> const DIR_SCALING_FACTOR = {{1.0, 1.0, 1.0}};
     };
 
     /** number of scalar fields that are reserved as temporary fields */

--- a/picongpu_setup_KHI/include/picongpu/param/particle.param
+++ b/picongpu_setup_KHI/include/picongpu/param/particle.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Axel Huebl, Rene Widera, Benjamin Worpitz,
+/* Copyright 2013-2024 Axel Huebl, Rene Widera, Benjamin Worpitz,
  *                     Richard Pausch, Klaus Steiniger
  *
  * This file is part of PIConGPU.
@@ -10,7 +10,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -34,36 +34,12 @@
 
 #include <pmacc/math/operation.hpp>
 
-
 namespace picongpu
 {
     namespace particles
     {
         namespace startPosition
         {
-
-            /** Define target number for marco-particles per cell
-             * to be used in Random start position functor.
-             */
-            struct RandomParameter
-            {
-                /** Maximum number of macro-particles per cell during density profile evaluation.
-                 *
-                 * Determines the weighting of a macro particle as well as the number of
-                 * macro-particles which sample the evolution of the particle distribution
-                 * function in phase space.
-                 *
-                 * unit: none
-                 */
-                static constexpr uint32_t numParticlesPerCell = 9u;
-            };
-            /** Definition of start position functor that randomly distributes macro-particles within a cell. */
-
-            using Random = RandomImpl<RandomParameter>;
-
-
-
-	  
             /** Define target number for marco-particles per cell along a direction.
              * To be used in Quiet start position functor.
              *
@@ -77,8 +53,11 @@ namespace picongpu
                 /** Count of macro-particles per cell per direction at initial state
                  *
                  *  unit: none */
-                using numParticlesPerDimension = mCT::shrinkTo<mCT::Int<3, 3, 1>, simDim>::type;
+                using numParticlesPerDimension = mCT::shrinkTo<
+                    mCT::Int<TYPICAL_PARTICLES_PER_CELL / 5, TYPICAL_PARTICLES_PER_CELL / 5, 1>,
+                    simDim>::type;
             };
+
             /** Definition of Quiet start position functor that positions macro-particles regularly on the grid.
              * No random number generator used.
              */
@@ -92,29 +71,21 @@ namespace picongpu
          *  unit: none */
         constexpr float_X MIN_WEIGHTING = 10.0;
 
-        /** Approximate number of maximum macro-particles per cell.
-         *
-         * Used internally for unit normalization.
-         */
-        constexpr uint32_t TYPICAL_PARTICLES_PER_CELL
-            = mCT::volume<startPosition::QuietParam::numParticlesPerDimension>::type::value;
-
         namespace manipulators
         {
-
             /** Define Lorentz factor of initial particle drift along +X. */
             struct DriftParamPositive
             {
                 static constexpr float_64 gamma = 1.021;
                 /** Define initial particle drift direction vector.
                  */
-                static constexpr auto driftDirection = float3_X(1.0, 0.0, 0.0);	      
+                static constexpr auto driftDirection = float3_X(1.0, 0.0, 0.0);
             };
+
             /** Definition of manipulator that assigns a drift in +X
              *  using parameters from struct DriftParamPositive.
              */
             using AssignXDriftPositive = unary::Drift<DriftParamPositive, pmacc::math::operation::Assign>;
-
 
             /** Define Lorentz factor of initial particle drift along -X. */
             struct DriftParamNegative
@@ -124,11 +95,11 @@ namespace picongpu
                  */
                 static constexpr auto driftDirection = float3_X(-1.0, 0.0, 0.0);
             };
+
             /** Definition of manipulator that assigns a drift in -X
              *  using parameters from struct DriftParamNegative.
              */
             using AssignXDriftNegative = unary::Drift<DriftParamNegative, pmacc::math::operation::Assign>;
-
 
             /** Define initial particle temperature. */
             struct TemperatureParam
@@ -138,6 +109,7 @@ namespace picongpu
                  */
                 static constexpr float_64 temperature = 0.0005;
             };
+
             /** Definition of manipulator assigning a temperature
              *  using parameters from struct TemperatureParam.
              */

--- a/picongpu_setup_KHI/include/picongpu/param/particleFilters.param
+++ b/picongpu_setup_KHI/include/picongpu/param/particleFilters.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Rene Widera
+/* Copyright 2013-2024 Rene Widera
  *
  * This file is part of PIConGPU.
  *
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -38,52 +38,51 @@
 #include <pmacc/traits/HasFlag.hpp>
 #include <pmacc/traits/HasIdentifiers.hpp>
 
-
 namespace picongpu
 {
     namespace particles
     {
         namespace filter
         {
-            struct IfRelativeGlobalPositionParamLowQuarterPosition
+            struct IfRelativeGlobalPositionParamLow8thPosition
             {
                 /* lowerBound is included in the range */
                 static constexpr float_X lowerBound = 0.0;
                 /* upperBound is excluded in the range */
-                static constexpr float_X upperBound = 0.25;
+                static constexpr float_X upperBound = 0.125;
                 /* dimension for the filter
                  * x = 0; y= 1; z = 2
                  */
                 static constexpr uint32_t dimension = 1u;
 
                 // filter name
-                static constexpr char const* name = "lowerQuarterYPosition";
+                static constexpr char const* name = "lower8thYPosition";
             };
 
-            using LowerQuarterYPosition
-                = filter::RelativeGlobalDomainPosition<IfRelativeGlobalPositionParamLowQuarterPosition>;
+            using Lower8thYPosition
+                = filter::RelativeGlobalDomainPosition<IfRelativeGlobalPositionParamLow8thPosition>;
 
-            struct IfRelativeGlobalPositionParamMiddleHalf
+            struct IfRelativeGlobalPositionParamMiddle
             {
                 /* lowerBound is included in the range */
-                static constexpr float_X lowerBound = 0.25;
+                static constexpr float_X lowerBound = 0.125;
                 /* upperBound is excluded in the range */
-                static constexpr float_X upperBound = 0.75;
+                static constexpr float_X upperBound = 0.725;
                 /* dimension for the filter
                  * x = 0; y= 1; z = 2
                  */
                 static constexpr uint32_t dimension = 1u;
 
                 // filter name
-                static constexpr char const* name = "middleHalfYPosition";
+                static constexpr char const* name = "middleYPosition";
             };
 
-            using MiddleHalfYPosition = filter::RelativeGlobalDomainPosition<IfRelativeGlobalPositionParamMiddleHalf>;
+            using MiddleYPosition = filter::RelativeGlobalDomainPosition<IfRelativeGlobalPositionParamMiddle>;
 
-            struct IfRelativeGlobalPositionParamUpperQuarter
+            struct IfRelativeGlobalPositionParamUpper3Eighth
             {
                 /* lowerBound is included in the range */
-                static constexpr float_X lowerBound = 0.75;
+                static constexpr float_X lowerBound = 0.625;
                 /* upperBound is excluded in the range */
                 static constexpr float_X upperBound = 1.0;
                 /* dimension for the filter
@@ -92,11 +91,11 @@ namespace picongpu
                 static constexpr uint32_t dimension = 1u;
 
                 // filter name
-                static constexpr char const* name = "upperQuarterYPosition";
+                static constexpr char const* name = "upper3EighthYPosition";
             };
 
-            using UpperQuarterYPosition
-                = filter::RelativeGlobalDomainPosition<IfRelativeGlobalPositionParamUpperQuarter>;
+            using Upper3EighthYPosition
+                = filter::RelativeGlobalDomainPosition<IfRelativeGlobalPositionParamUpper3Eighth>;
 
             /** Plugins: collection of all available particle filters
              *
@@ -105,7 +104,7 @@ namespace picongpu
              * Note: filter All is defined in picongpu/particles/filter/filter.def
              */
             using AllParticleFilters
-                = MakeSeq_t<All, LowerQuarterYPosition, MiddleHalfYPosition, UpperQuarterYPosition>;
+                = MakeSeq_t<All, Lower8thYPosition, MiddleYPosition, Upper3EighthYPosition>;
 
         } // namespace filter
 

--- a/picongpu_setup_KHI/include/picongpu/param/png.param
+++ b/picongpu_setup_KHI/include/picongpu/param/png.param
@@ -1,0 +1,97 @@
+/* Copyright 2013-2024 Axel Huebl, Heiko Burau, Rene Widera, Richard Pausch
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cmath>
+
+namespace picongpu
+{
+    /*scale image before write to file, only scale if value is not 1.0
+     */
+    constexpr float_64 scale_image = 1.0;
+
+    /*if true image is scaled if cellsize is not quadratic, else no scale*/
+    constexpr bool scale_to_cellsize = true;
+
+    constexpr bool white_box_per_GPU = true;
+
+    namespace visPreview
+    {
+        // normalize EM fields to typical laser or plasma quantities
+        //-1: Auto:     enable adaptive scaling for each output
+        // 1: Laser:    [outdated]
+        // 2: Drift:    [outdated]
+        // 3: PlWave:   typical fields calculated out of the plasma freq.,
+        //              assuming the wave moves approx. with c
+        // 4: Thermal:  [outdated]
+        // 5: BlowOut:  [outdated]
+        // 6: Custom:   user-provided normalization factors via customNormalizationSI
+        // 7: Incident: typical fields calculated out of the incident field amplitude,
+        //              uses max amplitude from all enabled incident field profile types ignoring Free
+#define EM_FIELD_SCALE_CHANNEL1 -1
+#define EM_FIELD_SCALE_CHANNEL2 -1
+#define EM_FIELD_SCALE_CHANNEL3 -1
+
+        /** SI values to be used for Custom normalization
+         *
+         * The order of normalization values is: B, E, current (note - current, not current density).
+         * This variable must always be defined, but has no effect for other normalization types.
+         */
+        constexpr float_64 customNormalizationSI[3] = {5.0e12 / sim.si.getSpeedOfLight(), 5.0e12, 15.0};
+
+        // multiply highest undisturbed particle density with factor
+        constexpr float_X preParticleDens_opacity = 0.25;
+        constexpr float_X preChannel1_opacity = 1.0;
+        constexpr float_X preChannel2_opacity = 1.0;
+        constexpr float_X preChannel3_opacity = 1.0;
+
+        // specify color scales for each channel
+        namespace preParticleDensCol = colorScales::red;
+        namespace preChannel1Col = colorScales::blue;
+        namespace preChannel2Col = colorScales::green;
+        namespace preChannel3Col = colorScales::none;
+
+        /** Calculate values for png channels for given field values
+         *
+         * @param field_B normalized magnetic field value
+         * @param field_E normalized electric field value
+         * @param field_Current normalized electric current value (note - not current density)
+         *
+         * @{
+         */
+        DINLINE float_X preChannel1(float3_X const& field_B, float3_X const& field_E, float3_X const& field_Current)
+        {
+            return field_B.z();
+        }
+
+        DINLINE float_X preChannel2(float3_X const& field_B, float3_X const& field_E, float3_X const& field_Current)
+        {
+            return -1.0_X * field_B.z();
+        }
+
+        DINLINE float_X preChannel3(float3_X const& field_B, float3_X const& field_E, float3_X const& field_Current)
+        {
+            return 1.0_X;
+        }
+
+        /** @} */
+    } // namespace visPreview
+
+} // namespace picongpu

--- a/picongpu_setup_KHI/include/picongpu/param/radiation.param
+++ b/picongpu_setup_KHI/include/picongpu/param/radiation.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Rene Widera, Richard Pausch
+/* Copyright 2013-2024 Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -64,22 +64,20 @@ namespace picongpu
                 constexpr unsigned int N_omega = 512; // number of frequencies
             } // namespace log_frequencies
 
-
             namespace frequencies_from_list
             {
                 /** path to text file with frequencies */
-                constexpr const char* listLocation = "/path/to/frequency.list";
+                constexpr char const* listLocation = "/path/to/frequency.list";
                 constexpr unsigned int N_omega = 2048; // number of frequencies
             } // namespace frequencies_from_list
 
 
             namespace radiation_frequencies = log_frequencies;
 
-
             namespace radiationNyquist
             {
                 constexpr float_32 NyquistFactor = 0.5;
-            }
+            } // namespace radiationNyquist
 
             ///////////////////////////////////////////////////
 
@@ -98,30 +96,36 @@ namespace picongpu
             namespace radFormFactor_CIC_3D
             {
             }
+
             namespace radFormFactor_TSC_3D
             {
             }
+
             namespace radFormFactor_PCS_3D
             {
             }
+
             namespace radFormFactor_CIC_1Dy
             {
             }
+
             namespace radFormFactor_Gauss_spherical
             {
             }
+
             namespace radFormFactor_Gauss_cell
             {
             }
+
             namespace radFormFactor_incoherent
             {
             }
+
             namespace radFormFactor_coherent
             {
             }
 
             namespace radFormFactor = radFormFactor_Gauss_spherical;
-
 
             ///////////////////////////////////////////////////////////
 
@@ -148,7 +152,6 @@ namespace picongpu
                 }
             };
 
-
             /* filter to enable radiation for electrons
              *
              * to enable the filter:
@@ -156,7 +159,6 @@ namespace picongpu
              *   - add the attribute `radiationMask` to the electron species
              */
             using RadiationParticleFilter = picongpu::particles::manipulators::generic::Free<GammaFilterFunctor>;
-
 
             //////////////////////////////////////////////////
 
@@ -175,15 +177,19 @@ namespace picongpu
             namespace radWindowFunctionTriangle
             {
             }
+
             namespace radWindowFunctionHamming
             {
             }
+
             namespace radWindowFunctionTriplett
             {
             }
+
             namespace radWindowFunctionGauss
             {
             }
+
             namespace radWindowFunctionNone
             {
             }

--- a/picongpu_setup_KHI/include/picongpu/param/radiationObserver.param
+++ b/picongpu_setup_KHI/include/picongpu/param/radiationObserver.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Heiko Burau, Rene Widera, Richard Pausch
+/* Copyright 2013-2024 Heiko Burau, Rene Widera, Richard Pausch
  *
  * This file is part of PIConGPU.
  *
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -19,6 +19,8 @@
 
 
 #pragma once
+
+#include "picongpu/plugins/radiation/VectorTypes.hpp"
 
 namespace picongpu
 {
@@ -42,7 +44,7 @@ namespace picongpu
                  *           type: vector_64
                  *
                  */
-                HDINLINE vector_64 observationDirection(const int observation_id_extern)
+                HDINLINE vector_64 observationDirection(int const observation_id_extern)
                 {
                     /** This computes observation directions for one octant
                      *  of a sphere around the simulation area.
@@ -50,35 +52,6 @@ namespace picongpu
                      *  (+1,0,0) ; (0,+1,0) ; (0,0,-1)
                      */
 
-                    /* float type used in radiation direction calculations */
-                    using float_obs = picongpu::float_X;
-
-                    /* generate two indices from single block index */
-		    //                    constexpr int N_angle_split = 16; /* index split distance */
-                    /* get column index for computing angle theta: */
-		    //                    const int my_index_theta = observation_id_extern / N_angle_split;
-                    /* get row index for computing angle phi: */
-		    //                    const int my_index_phi = observation_id_extern % N_angle_split;
-
-                    /*  range for BOTH angles */
-		    //                    constexpr picongpu::float_64 angle_range = picongpu::PI / 2.0;
-
-                    /* angle stepwidth for BOTH angles */
-		    //                    constexpr picongpu::float_64 delta_angle_phi = 1.0 * angle_range / (N_angle_split - 1);
-		    //		    constexpr picongpu::float_64 delta_angle_theta = 1.0 * angle_range / (N_angle_split/2 - 1);
-
-                    /* compute both angles */
-		    //                    const picongpu::float_64 theta(my_index_theta * delta_angle_theta + 0.5 * picongpu::PI);
-		    //                    const picongpu::float_64 phi(my_index_phi * delta_angle_phi);
-
-                    /* compute unit vector */
-		    //                    float_obs sinPhi;
-		    //                    float_obs cosPhi;
-		    //                    float_obs sinTheta;
-		    //                    float_obs cosTheta;
-		    //                    pmacc::math::sincos(precisionCast<float_obs>(phi), sinPhi, cosPhi);
-		    //                    pmacc::math::sincos(precisionCast<float_obs>(theta), sinTheta, cosTheta);
-		    //                    return vector_64(sinTheta * cosPhi, sinTheta * sinPhi, cosTheta);
 		    switch ( observation_id_extern ){
 		      case 0:
 		        return vector_64(1.0, 0.0, 0.0);

--- a/picongpu_setup_KHI/include/picongpu/param/simulation.param
+++ b/picongpu_setup_KHI/include/picongpu/param/simulation.param
@@ -1,0 +1,96 @@
+/* Copyright 2013-2024 Axel Huebl, Rene Widera, Richard Pausch,
+ *                     Benjamin Worpitz
+ *
+ * This file is part of PIConGPU.
+ *
+ * PIConGPU is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PIConGPU is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PIConGPU.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *
+ * Definition of cell sizes and time step. Our cells are defining a regular,
+ * cartesian grid. Our explicit FDTD field solvers require an upper bound for
+ * the time step value in relation to the cell size for convergence. Make
+ * sure to resolve important wavelengths of your simulation, e.g. shortest
+ * plasma wavelength, Debye length and central laser wavelength both spatially
+ * and temporarily.
+ *
+ * **Units in reduced dimensions**
+ *
+ * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+ * is still used for normalization of densities, etc..
+ *
+ * A 2D3V simulation in a cartesian PIC simulation such as
+ * ours only changes the degrees of freedom in motion for
+ * (macro) particles and all (field) information in z
+ * travels instantaneously, making the 2D3V simulation
+ * behave like the interaction of infinite "wire particles"
+ * in fields with perfect symmetry in Z.
+ *
+ */
+
+#pragma once
+
+namespace picongpu
+{
+    namespace SI
+    {
+        /** Duration of one timestep
+         *  unit: seconds */
+        constexpr float_64 DELTA_T_SI = 1.79e-16;
+
+        /** equals X
+         *  unit: meter */
+
+        /** equals X
+         *  unit: meter */
+        constexpr float_64 CELL_WIDTH_SI = 9.34635e-8;
+        /** equals Y
+         *  unit: meter */
+        constexpr float_64 CELL_HEIGHT_SI = CELL_WIDTH_SI;
+        /** equals Z
+         *  unit: meter */
+        constexpr float_64 CELL_DEPTH_SI = CELL_WIDTH_SI;
+
+        /** Note on units in reduced dimensions
+         *
+         * In 2D3V simulations, the CELL_DEPTH_SI (Z) cell length
+         * is still used for normalization of densities, etc.
+         *
+         * A 2D3V simulation in a cartesian PIC simulation such as
+         * ours only changes the degrees of freedom in motion for
+         * (macro) particles and all (field) information in z
+         * travels instantaneously, making the 2D3V simulation
+         * behave like the interaction of infinite "wire particles"
+         * in fields with perfect symmetry in Z.
+         */
+
+        /** Base density in particles per m^3 in the density profiles.
+         *
+         * This is often taken as reference maximum density in normalized profiles.
+         * Individual particle species can define a `densityRatio` flag relative
+         * to this value.
+         *
+         * unit: ELEMENTS/m^3
+         */
+        constexpr float_64 BASE_DENSITY_SI = 1.e25;
+    } // namespace SI
+
+    /** (Approximate) Number of maximum macro-particles per cell.
+     *
+     * Used internally for unit normalization.
+     */
+    constexpr uint32_t TYPICAL_PARTICLES_PER_CELL = 25u;
+} // namespace picongpu

--- a/picongpu_setup_KHI/include/picongpu/param/speciesDefinition.param
+++ b/picongpu_setup_KHI/include/picongpu/param/speciesDefinition.param
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 Rene Widera, Benjamin Worpitz, Heiko Burau
+/* Copyright 2013-2024 Rene Widera, Benjamin Worpitz, Heiko Burau
  *
  * This file is part of PIConGPU.
  *
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "picongpu/simulation_defines.hpp"
 
 #include "picongpu/particles/Particles.hpp"
 
@@ -30,10 +29,6 @@
 #include <pmacc/particles/traits/FilterByFlag.hpp>
 
 
-#ifndef PARAM_RADIATION
-/* disable radiation calculation */
-#    define PARAM_RADIATION 0
-#endif
 
 
 namespace picongpu
@@ -45,8 +40,7 @@ namespace picongpu
         position<position_pic>,
         momentum,
         weighting,
-        momentumPrev1,
-	particleId
+        momentumPrev1
         >;
 
     /*########################### end particle attributes ########################*/
@@ -55,7 +49,7 @@ namespace picongpu
 
     /*--------------------------- electrons --------------------------------------*/
 
-    /* ratio relative to BASE_CHARGE and BASE_MASS */
+    /* ratio relative to base charge and base mass */
     value_identifier(float_X, MassRatioElectrons, 1.0);
     value_identifier(float_X, ChargeRatioElectrons, 1.0);
 
@@ -72,7 +66,7 @@ namespace picongpu
 
     /*--------------------------- ions -------------------------------------------*/
 
-    /* ratio relative to BASE_CHARGE and BASE_MASS */
+    /* ratio relative to base charge and base mass */
     value_identifier(float_X, MassRatioIons, 1836.152672);
     value_identifier(float_X, ChargeRatioIons, -1.0);
 

--- a/picongpu_setup_KHI/include/picongpu/param/speciesInitialization.param
+++ b/picongpu_setup_KHI/include/picongpu/param/speciesInitialization.param
@@ -1,4 +1,4 @@
-/* Copyright 2015-2022 Rene Widera, Axel Huebl
+/* Copyright 2015-2024 Rene Widera, Axel Huebl
  *
  * This file is part of PIConGPU.
  *
@@ -9,7 +9,7 @@
  *
  * PIConGPU is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
@@ -30,7 +30,6 @@
 
 #include "picongpu/particles/InitFunctors.hpp"
 
-
 namespace picongpu
 {
     namespace particles
@@ -40,14 +39,14 @@ namespace picongpu
          * the functors are called in order (from first to last functor)
          */
         using InitPipeline = pmacc::mp_list<
-            CreateDensity<densityProfiles::Homogenous, startPosition::Random, PIC_Electrons>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet, PIC_Electrons>,
             Derive<PIC_Electrons, PIC_Ions>,
-            Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::LowerQuarterYPosition>,
-            Manipulate<manipulators::AssignXDriftNegative, PIC_Ions, filter::MiddleHalfYPosition>,
-            Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::UpperQuarterYPosition>,
-            Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::LowerQuarterYPosition>,
-            Manipulate<manipulators::AssignXDriftNegative, PIC_Electrons, filter::MiddleHalfYPosition>,
-            Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::UpperQuarterYPosition>,
+            Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::Lower8thYPosition>,
+            Manipulate<manipulators::AssignXDriftNegative, PIC_Ions, filter::MiddleYPosition>,
+            Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::Upper3EighthYPosition>,
+            Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::Lower8thYPosition>,
+            Manipulate<manipulators::AssignXDriftNegative, PIC_Electrons, filter::MiddleYPosition>,
+            Manipulate<manipulators::AssignXDriftPositive, PIC_Electrons, filter::Upper3EighthYPosition>,
             Manipulate<manipulators::AddTemperature, PIC_Electrons>>;
 
     } // namespace particles


### PR DESCRIPTION
This PR adds the [0, 1/8) [1/8, 5/8) [5/8, 8,8) distribution for the KHI and a smaller cfg file (for only 4 GPUs).
This was developed during the frontier hackathon but seems to be never included into this repo. 