### PR TITLE
picongpu_setup_KHI/small: Random species init

### DIFF
--- a/picongpu_setup_KHI/small/include/picongpu/param/speciesInitialization.param
+++ b/picongpu_setup_KHI/small/include/picongpu/param/speciesInitialization.param
@@ -39,7 +39,7 @@ namespace picongpu
          * the functors are called in order (from first to last functor)
          */
         using InitPipeline = pmacc::mp_list<
-            CreateDensity<densityProfiles::Homogenous, startPosition::Quiet, PIC_Electrons>,
+            CreateDensity<densityProfiles::Homogenous, startPosition::Random, PIC_Electrons>,
             Derive<PIC_Electrons, PIC_Ions>,
             Manipulate<manipulators::AssignXDriftPositive, PIC_Ions, filter::Lower8thYPosition>,
             Manipulate<manipulators::AssignXDriftNegative, PIC_Ions, filter::MiddleYPosition>,


### PR DESCRIPTION
@PrometheusPi is this the whole change to make the small KHI setup have random particle init, like the large one?